### PR TITLE
composer.json fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "hashids/hashids": "0.3.*@dev",
-        "symfony/framework-standard-edition": ">= 2.1.0"
+        "symfony/framework-bundle": ">= 2.1.0"
         },
     "authors": [
         {
@@ -15,7 +15,6 @@
             "email": "neoshadybeat@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
     "autoload": {
         "psr-0": { "cayetanosoriano\\HashidsBundle": "" }
     },


### PR DESCRIPTION
Just fixed composer dependency.
Not everybody use "symfony/framework-standard-edition". One can use "symfony/symfony" or something else. So I think it would be better to depend on "symfony/framework-bundle" which is used everywhere, like in other popular bundles:
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/composer.json

Also removed second "minimum-stability": "dev" as it was written twice in the this file
