### PR TITLE
Mark package as stable and create a new working tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Bundle for integration of hashids lib to the container",
     "keywords": ["hashids"],
     "type": "symfony-bundle",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "license": "MIT",
     "require": {
         "hashids/hashids": "~1.0",


### PR DESCRIPTION
Hi,

I guess package could be marked as a stable one, which will allow people with composer `minimum-stability` setting set to `stable`.

Also, it needs a new, working tag as `dev-master` shouldn't be used on production environments.