### PR TITLE
Add Hashids-aware extension of DoctrineParamConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ the Hashid encoded version.
 
 ```php
 /**
- * @Route("/user/{id}", requirements={"id"="\d+"}, name="user_profile")
+ * @Route("/user/{id}", requirements={"id"="\d+"}, name="user_view")
  */
 public function viewAction(User $user)
 {
@@ -103,7 +103,7 @@ version of `id`.
 
 ```php
 /**
- * @Route("/user/{hashid}", requirements={"hashid"="[A-Za-z0-9_-]+"}, name="user_profile")
+ * @Route("/user/{hashid}", requirements={"hashid"="[A-Za-z0-9_-]+"}, name="user_view")
  */
 public function viewAction(User $user)
 {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,55 @@ cayetanosoriano_hashids:
 $kcy = $this->get('hashids');
 ```
 
+## Optional features
+
+### Doctrine param converter
+
+The included Doctrine param converter extends the one included in
+(SensioFrameworkExtraBundle)[http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html]
+to automate decoding of Hashids in routes before fetching the object.
+
+#### Overload the default service to your services.yml
+
+```yaml
+sensio_framework_extra.converter.doctrine.orm:
+    class: cayetanosoriano\HashidsBundle\Request\ParamConverter\HashidsDoctrineParamConverter
+    arguments: ["@hashids", "@doctrine"]
+    tags: [{ name: request.param_converter, converter: doctrine.orm }]
+```
+
+#### Specify the Hashid in your route
+
+The following two examples are equivalent, using either the raw database `id` or
+the Hashid encoded version.
+
+##### Raw `id` (standard SensioFrameworkExtraBundle behaviour)
+
+```php
+/**
+ * @Route("/user/{id}", requirements={"id"="\d+"}, name="user_profile")
+ */
+public function viewAction(User $user)
+{
+…
+}
+```
+
+##### Hashid
+
+The `hashid` request parameter will be automatically recognised as an encoded
+version of `id`.
+
+```php
+/**
+ * @Route("/user/{hashid}", requirements={"hashid"="[A-Za-z0-9_-]+"}, name="user_profile")
+ */
+public function viewAction(User $user)
+{
+…
+}
+```
+
 ### license
 ```
 Copyright (c) 2015 neoshadybeat[at]gmail.com

--- a/Request/ParamConverter/HashidsDoctrineParamConverter.php
+++ b/Request/ParamConverter/HashidsDoctrineParamConverter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace cayetanosoriano\HashidsBundle\Request\ParamConverter;
+
+use Hashids\Hashids;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Jaik Dean <jaik@fluoresce.co>
+ */
+class HashidsDoctrineParamConverter extends DoctrineParamConverter
+{
+    /**
+     * @var Hashids\Hashids
+     */
+    protected $hashids;
+
+    public function __construct(Hashids $hashids, ManagerRegistry $registry = null)
+    {
+        $this->hashids = $hashids;
+        parent::__construct($registry);
+    }
+
+    protected function getIdentifier(Request $request, $options, $name)
+    {
+        // Default to the standard DoctrineParamConverter behaviour
+        $parent = parent::getIdentifier($request, $options, $name);
+
+        if ($parent !== false) {
+            return $parent;
+        }
+
+        // If an identifier wasn’t found, check for a Hashid
+        if ($request->attributes->has('hashid')) {
+            $id = $request->attributes->get('hashid');
+            return $this->hashids->decode($id);
+        }
+
+        return false;
+    }
+}

--- a/Request/ParamConverter/HashidsDoctrineParamConverter.php
+++ b/Request/ParamConverter/HashidsDoctrineParamConverter.php
@@ -35,7 +35,8 @@ class HashidsDoctrineParamConverter extends DoctrineParamConverter
         // If an identifier wasn’t found, check for a Hashid
         if ($request->attributes->has('hashid')) {
             $id = $request->attributes->get('hashid');
-            return $this->hashids->decode($id);
+            $decoded = $this->hashids->decode($id);
+            return $decoded[0];
         }
 
         return false;


### PR DESCRIPTION
This PR adds an optional param converter extension which allows easy conversion of Hashids in URLs to Doctrine entities in Controller methods.

For example:
```php
/**
 * @Route("/user/{hashid}", requirements={"hashid"="[A-Za-z0-9_-]+"}, name="user_view")
 */
public function viewAction(User $user)
{
…
}
```