### PR TITLE
fixes: exception "Undefined offset: 0" array-index access on empty array

### DIFF
--- a/Request/ParamConverter/HashidsDoctrineParamConverter.php
+++ b/Request/ParamConverter/HashidsDoctrineParamConverter.php
@@ -36,7 +36,9 @@ class HashidsDoctrineParamConverter extends DoctrineParamConverter
         if ($request->attributes->has('hashid')) {
             $id = $request->attributes->get('hashid');
             $decoded = $this->hashids->decode($id);
-            return $decoded[0];
+            if (array_key_exists(0, $decoded) {
+                return $decoded[0];
+            }
         }
 
         return false;


### PR DESCRIPTION
Hashids::decode may return an empty array