### PR TITLE
annotation correction

### DIFF
--- a/Request/ParamConverter/HashidsDoctrineParamConverter.php
+++ b/Request/ParamConverter/HashidsDoctrineParamConverter.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 class HashidsDoctrineParamConverter extends DoctrineParamConverter
 {
     /**
-     * @var Hashids\Hashids
+     * @var Hashids
      */
     protected $hashids;
 


### PR DESCRIPTION
Hashids is defined as Hashids\Hashids in a use statement, making this annotation invalid