### PR TITLE
Fix PHP syntax error - T_RETURN

### DIFF
--- a/Request/ParamConverter/HashidsDoctrineParamConverter.php
+++ b/Request/ParamConverter/HashidsDoctrineParamConverter.php
@@ -36,7 +36,7 @@ class HashidsDoctrineParamConverter extends DoctrineParamConverter
         if ($request->attributes->has('hashid')) {
             $id = $request->attributes->get('hashid');
             $decoded = $this->hashids->decode($id);
-            if (array_key_exists(0, $decoded) {
+            if (array_key_exists(0, $decoded)) {
                 return $decoded[0];
             }
         }


### PR DESCRIPTION
fix missing bracket ) in dev-master

```
 Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Parse error:
  syntax error, unexpected 'return' (T_RETURN) in /Users/phil/Sites/digitaljersey/vendor/cay
  etanosoriano/hashids-bundle/cayetanosoriano/HashidsBundle/Request/ParamConverter/HashidsDo
  ctrineParamConverter.php:40
```